### PR TITLE
Add unbound.d directory so users can mount additional config files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,8 @@ RUN apk --update add --no-cache unbound wget \
 
 COPY unbound.conf /etc/unbound/
 
+RUN mkdir /etc/unbound/unbound.d
+
+VOLUME /etc/unbound/unbound.d
+
 ENTRYPOINT ["unbound", "-d"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,11 +4,10 @@ LABEL maintainer Mijndert Stuij "mijndert@mijndertstuij.nl"
 
 RUN apk --update add --no-cache unbound wget \
     && rm -rf /var/cache/apk/* /src/* \
-    && wget -S -N https://www.internic.net/domain/named.cache -O /etc/unbound/root.hints
+    && wget -S -N https://www.internic.net/domain/named.cache -O /etc/unbound/root.hints \
+    && mkdir -p /etc/unbound/unbound.d
 
 COPY unbound.conf /etc/unbound/
-
-RUN mkdir /etc/unbound/unbound.d
 
 VOLUME /etc/unbound/unbound.d
 

--- a/unbound.conf
+++ b/unbound.conf
@@ -31,5 +31,5 @@ server:
 
 	statistics-cumulative: yes
 	
-	include /etc/unbound/unbound.d/*.conf
+	include: /etc/unbound/unbound.d/*.conf
 	

--- a/unbound.conf
+++ b/unbound.conf
@@ -31,3 +31,5 @@ server:
 
 	statistics-cumulative: yes
 	
+	include /etc/unbound/unbound.d/*.conf
+	


### PR DESCRIPTION
This PR modifies the Dockerfile and the unbound.conf configuration files to load additional files from a `/etc/unbound/unbound.d` directory. This enables users to add additional configuration if they desire so. 